### PR TITLE
feat: drawing over multiple array to allow for lock independent writing

### DIFF
--- a/atlas/command.go
+++ b/atlas/command.go
@@ -93,7 +93,7 @@ func (dl *DrawList) Add(commands ...*DrawCommand) {
 			dl.vx, dl.ix, batch.end, opts,
 		)
 
-		//if len(dl.ix) >=
+		// if len(dl.ix) >=
 
 		batch.end++
 	}
@@ -173,4 +173,50 @@ func (dl *DrawList) FlushWithShader(dst *ebiten.Image, shader *ebiten.Shader, op
 	dl.ranges = dl.ranges[:0]
 	dl.vx = dl.vx[:0]
 	dl.ix = dl.ix[:0]
+}
+
+func NewDDListMultiple(size int) *DraListMultiple {
+	return &DraListMultiple{
+		lists: make([]*DrawList, size),
+	}
+}
+
+type DraListMultiple struct {
+	lists []*DrawList
+}
+
+func (dd1 *DraListMultiple) Add(index int, list *DrawList) {
+	dd1.lists[index] = list
+}
+
+func (dd1 *DraListMultiple) Flush(dst *ebiten.Image, opts *DrawOptions) {
+	var topts *ebiten.DrawTrianglesOptions
+	if opts != nil {
+		topts = &ebiten.DrawTrianglesOptions{
+			ColorScaleMode: opts.ColorScaleMode,
+			Blend:          opts.Blend,
+			Filter:         opts.Filter,
+			Address:        opts.Address,
+			AntiAlias:      opts.AntiAlias,
+		}
+	}
+	for _, dl := range dd1.lists {
+		index := 0
+		if dl == nil {
+			continue
+		}
+		for _, r := range dl.ranges {
+			dst.DrawTriangles(
+				dl.vx[index*4:(index+r.end)*4],
+				dl.ix[index*6:(index+r.end)*6],
+				r.atlas.native,
+				topts,
+			)
+			index += r.end
+		}
+		// Clear buffers
+		dl.ranges = dl.ranges[:0]
+		dl.vx = dl.vx[:0]
+		dl.ix = dl.ix[:0]
+	}
 }


### PR DESCRIPTION
This allows for very easy concurrent writing mode.

Probably suboptimal but makes stuff way faster.

Sample results from using `runtime.NumCPU()` with 30k objects.

|after | before |
|------|------|
| 2.285709|11.767208| 
| 2.322709|10.353125| 
| 2.237125|7.644208| 
| 2.43175|6.616167| 
| 2.15925|6.79775| 
| 2.153958|7.107583| 
| 2.430291|6.664375| 
| 2.04325|6.643875| 
| 1.918875|8.930292| 
| 2.166291|9.248416| 
| 2.350708|6.876833| 
| 1.9675|6.85375| 
| 2.100167|7.601167| 
| 2.120541|6.568125| 
| 3.812584|6.657958| 
| 2.211542|6.6655| 
| 2.085417|7.035833| 
| 2.294625|6.593917| 
| 1.981083|6.605375| 
| 2.289625|8.687709| 
| 2.285333|6.658666| 
| 2.144209|6.820375| 
| 2.137167|6.811666| 
| 2.296916|6.970667| 
| 2.098375|6.632334| 
| 2.031584|6.652125| 
| 2.29225|7.331667| 
| 2.086958|6.67| 
| 10.4495|6.5625| 
| 2.263542|6.614458| 
| 1.993875|7.177458| 
| 2.054791|6.608417| 
| 2.540625|6.633708| 
| 2.1495|8.067416| 
| 2.183334|7.948292| 
| 2.467583|7.099708| 
| 2.23675|6.594667| 
| 2.21725|6.61975| 
| 2.128708|7.029125| 
| 3.34475|6.892916| 
| 2.029667|6.5825| 
| 2.112625|6.578792| 
| 2.006916|7.327042| 
| 2.083833|6.704334| 
| 2.381|6.661959| 
| 2.275|7.379917| 
| 2.045334|6.639583| 
| 2.084375|6.554292| 
| 2.145791|6.886458| 
| 2.135041|6.662084| 